### PR TITLE
Update downloads.haml

### DIFF
--- a/downloads.haml
+++ b/downloads.haml
@@ -356,7 +356,7 @@
             \:
             In Debian you can fetch htop by typing:
             %tt
-              apt-get install htop
+              apt install htop
             %br/
             You can also download the binary packages from the
             = succeed "." do
@@ -366,9 +366,9 @@
           %li
             %b> Fedora
             \:
-            htop is part of Fedora Extras; you can fetch it by typing:
+            htop is included in the Fedora repositories; you can fetch it with:
             %tt
-              yum install htop
+              dnf install htop
             %br/
             Thanks to Dawid Gajownik.
           %li


### PR DESCRIPTION
- Recent Debian versions favor apt over apt-get
- Fedora now uses dnf instead of yum

I don't know if the instructions for the other distros are still up to date. I am only familiar with Debian and Fedora.