### PR TITLE
Fix overflow youtube video

### DIFF
--- a/assets/css/htop.css
+++ b/assets/css/htop.css
@@ -130,6 +130,26 @@ img {
    max-width: 100%;
 }
 
+.video-wrapper {
+  display: flex;
+  justify-content: center;
+}
+
+@media (max-width: 600px) {
+  .video-wrapper {
+    position: relative;
+    height: 0;
+    padding-top: 56.25%;
+  }
+  .video-wrapper iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}
+
 @media (max-width: 999px) {
    .content {
       margin-top: 50px;

--- a/docs/assets/css/htop.css
+++ b/docs/assets/css/htop.css
@@ -130,6 +130,26 @@ img {
    max-width: 100%;
 }
 
+.video-wrapper {
+  display: flex;
+  justify-content: center;
+}
+
+@media (max-width: 600px) {
+  .video-wrapper {
+    position: relative;
+    height: 0;
+    padding-top: 56.25%;
+  }
+  .video-wrapper iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}
+
 @media (max-width: 999px) {
    .content {
       margin-top: 50px;

--- a/docs/index.html
+++ b/docs/index.html
@@ -106,9 +106,9 @@ And here is Hisham's lightning talk at
 <a href='https://fosdem.org'>FOSDEM</a>
 presenting the latest and upcoming features:
 </p>
-<p style='text-align:center'>
+<div class='video-wrapper'>
 <iframe allow='autoplay; encrypted-media' allowfullscreen='' frameborder='0' height='315' src='https://www.youtube-nocookie.com/embed/L25waVhy78o' width='560'></iframe>
-</p>
+</div>
 <p>
 Since version 2.0, htop is now
 <a href='https://fosdem.org/2016/schedule/event/htop/'>cross-platform!</a>

--- a/index.haml
+++ b/index.haml
@@ -28,7 +28,7 @@
           And here is Hisham's lightning talk at
           %a{:href => "https://fosdem.org"} FOSDEM
           presenting the latest and upcoming features:
-        %p{:style => "text-align:center"}
+        %div.video-wrapper
           %iframe{:allow => "autoplay; encrypted-media", :allowfullscreen => "", :frameborder => "0", :height => "315", :src => "https://www.youtube-nocookie.com/embed/L25waVhy78o", :width => "560"}
         %p
           Since version 2.0, htop is now


### PR DESCRIPTION
### Description

On a short screen, the embedded video starts overflowing its parent because the container size is smaller than the declared width (`560px`). Hope this patch will address that problem. Let me know what you think

### Screenshot

| Before    | After   |
| --------- | ------- |
| ![Screenshot_2020-10-02 htop - an interactive process viewer(1)](https://user-images.githubusercontent.com/33394747/94936467-79651400-04f8-11eb-8ede-d35498eb8821.png) | ![Screenshot_2020-10-02 htop - an interactive process viewer](https://user-images.githubusercontent.com/33394747/94936472-7bc76e00-04f8-11eb-9428-68d3b1b810e9.png) |
