### PR TITLE
Change macOS name on the main page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -117,7 +117,7 @@ Check out the
 and
 <a href='htop_talk.pdf'>slides</a>
 of Hisham's presentation at FOSDEM 2016 about how this came to be.
-This release includes code supporting Linux, FreeBSD, OpenBSD, DragonFly BSD and MacOSX.
+This release includes code supporting Linux, FreeBSD, OpenBSD, DragonFly BSD and macOS.
 </p>
 <center>
 <p>

--- a/index.haml
+++ b/index.haml
@@ -19,7 +19,7 @@
         %h2 What's new in htop
         %p
           The latest releases in htop include pressure stall information
-          for Linux, ZFS ARC statistics, more than two processor columns, 
+          for Linux, ZFS ARC statistics, more than two processor columns,
           as well as many other features and bugfixes.
           Check out the
           %a{:href => "https://github.com/htop-dev/htop/blob/master/ChangeLog"} changelog
@@ -38,7 +38,7 @@
           and
           %a{:href => "htop_talk.pdf"} slides
           of Hisham's presentation at FOSDEM 2016 about how this came to be.
-          This release includes code supporting Linux, FreeBSD, OpenBSD, DragonFly BSD and MacOSX.
+          This release includes code supporting Linux, FreeBSD, OpenBSD, DragonFly BSD and macOS.
         %center
           %p
             %a{:href => "images/htop-2.0.png"}


### PR DESCRIPTION
The previous official name is OS X, the one before that is Mac OS X. The current one is [macOS](https://www.apple.com/macos/).